### PR TITLE
rename lowbatt to lowbat in de-DE.csv

### DIFF
--- a/voices/de-DE.csv
+++ b/voices/de-DE.csv
@@ -214,7 +214,7 @@ SOUNDS/de;engoff.wav;Motor aus
 SOUNDS/de;engon.wav;Motor an
 SOUNDS/de;tohigh.wav;zu hoch
 SOUNDS/de;tolow.wav;zu niedrig
-SOUNDS/de;lowbatt.wav;Batterie schwach
+SOUNDS/de;lowbat.wav;Batterie schwach
 SOUNDS/de;crowon.wav;Butterfly ein
 SOUNDS/de;crowof.wav;Butterfly aus
 SOUNDS/de;fm-spd.wav;Geschwindigkeits-Modus ist aktiviert


### PR DESCRIPTION
only sounds with 6 letters are shown in the selection menu
the issue is only in this file, all others are fine