### PR TITLE
chore(ci): node20 updates

### DIFF
--- a/.github/workflows/build_checks.yml
+++ b/.github/workflows/build_checks.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run build checks
         run: ./build-checks.py

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -25,7 +25,7 @@ jobs:
           pip3 install ffmpeg-normalize
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run build checks
         run: ./build-checks.py


### PR DESCRIPTION
Update action versions due to github node16 => node20 transition. c.f. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/