### PR TITLE
ci: update workflow actions for Node 24 and maintained releases

### DIFF
--- a/.github/workflows/build_checks.yml
+++ b/.github/workflows/build_checks.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run build checks
         run: ./build-checks.py

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,9 +16,11 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -27,7 +29,9 @@ jobs:
           sudo apt-get update && sudo apt-get install --yes --no-install-recommends ffmpeg
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Python dependencies
         run: uv sync
@@ -43,25 +47,39 @@ jobs:
         if: github.event_name != 'pull_request'
         run: ./release.sh
 
-      - name: Auto Release to Latest
-        uses: crowbarmaster/GH-Automatic-Releases@latest
+      - name: Update latest tag
+        if: github.event_name != 'pull_request' && !startsWith(github.event.ref, 'refs/tags/v')
+        run: |
+          git tag -f latest
+          git push -f origin latest
+
+      - name: Delete previous latest release
+        if: github.event_name != 'pull_request' && !startsWith(github.event.ref, 'refs/tags/v')
+        run: gh release delete latest --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy latest prerelease
+        uses: softprops/action-gh-release@v2
         if: github.event_name != 'pull_request' && !startsWith(github.event.ref, 'refs/tags/v')
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          title: "Latest"
-          automatic_release_tag: "latest"
+          tag_name: latest
+          target_commitish: ${{ github.sha }}
           prerelease: true
+          name: Latest
+          generate_release_notes: true
           files: |
             release/edgetx-sdcard-sounds-*.zip
             sounds.json
 
       - name: Auto Create Draft Release
-        uses: crowbarmaster/GH-Automatic-Releases@latest
+        uses: softprops/action-gh-release@v2
         if: ${{ startsWith(github.event.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: ${{ github.ref_name }}
           draft: true
           prerelease: false
+          generate_release_notes: true
           files: |
             release/edgetx-sdcard-sounds-*.zip
             sounds.json


### PR DESCRIPTION
## Summary
- bump core GitHub Actions to current major versions (checkout/setup-python/setup-uv)
- replace unmaintained GH-Automatic-Releases with softprops/action-gh-release
- add latest-tag refresh and latest-release recreation flow for prereleases
- keep tagged builds as draft releases with generated notes

## Details
- .github/workflows/build_checks.yml:
  - actions/setup-python: v5 -> v6
  - actions/checkout: v4 -> v6
- .github/workflows/build_release.yml:
  - astral-sh/setup-uv: v4 -> v7
  - actions/checkout: v4 -> v6 (fetch-depth: 0)
  - replace crowbarmaster/GH-Automatic-Releases with softprops/action-gh-release@v2
  - add latest tag update + previous latest release deletion before prerelease publish
  - add permissions.contents: write for release/tag operations